### PR TITLE
feat: Add ability to comment/annotate an entry

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -24,6 +24,7 @@ all: add \
   report-per-day-csv \
   report-month \
   report-details \
+  report-comments \
   version
 
 $(UTT):
@@ -314,6 +315,18 @@ report-details: $(UTT)
 	bash -c 'diff -u <(utt --now "2018-08-21 20:00" report --from 2018-08-20 --to 2018-08-21 --details) data/utt-report-details.stdout'
 
 	@echo "<< REPORT-DETAILS"
+
+
+.PHONY: report-comments
+report-commentss: $(UTT)
+	@echo
+	@echo ">> REPORT-COMMENTS"
+
+	mkdir -p `dirname $(UTT_DATA_FILENAME)`
+	cp data/utt-report-project.log $(UTT_DATA_FILENAME)
+	bash -c 'diff -u <(utt --now "2018-08-21 20:00" report --from 2018-08-20 --to 2018-08-21 --details --comments) data/utt-report-comments.stdout'
+
+	@echo "<< REPORT-COMMENTS"
 
 
 .PHONY: shell

--- a/test/integration/data/utt-report-comments.stdout
+++ b/test/integration/data/utt-report-comments.stdout
@@ -1,0 +1,39 @@
+
+------ Monday, Aug 20, 2018 (week 34) to Tuesday, Aug 21, 2018 (week 34) -------
+
+Working Time: 1h00
+Break   Time: 0h00
+
+----------------------------------- Projects -----------------------------------
+
+(0h30) project_1: task_1, task_2, task_3
+(0h30) project_2: task_1, task_2, task_3
+
+---------------------------------- Activities ----------------------------------
+
+(0h12) project_1: task_1
+(0h12) project_1: task_2
+(0h06) project_1: task_3
+(0h12) project_2: task_1
+(0h12) project_2: task_2
+(0h06) project_2: task_3
+
+
+----------------------------------- Details ------------------------------------
+
+2018-08-20:
+
+(0h06) 08:00-08:06 project_1: task_1
+(0h06) 08:06-08:12 project_2: task_1
+(0h06) 08:12-08:18 project_1: task_2
+(0h06) 08:18-08:24 project_2: task_2
+
+2018-08-21:
+
+(0h06) 08:00-08:06 project_1: task_1
+(0h06) 08:06-08:12 project_2: task_1
+(0h06) 08:12-08:18 project_1: task_2
+(0h06) 08:18-08:24 project_2: task_2
+(0h06) 08:24-08:30 project_1: task_3  # creating tests for task_3
+(0h06) 08:30-08:36 project_2: task_3  # refactoring project_2 UI
+

--- a/test/integration/data/utt-report-project.log
+++ b/test/integration/data/utt-report-project.log
@@ -9,5 +9,5 @@
 2018-08-21 08:12 project_2: task_1
 2018-08-21 08:18 project_1: task_2
 2018-08-21 08:24 project_2: task_2
-2018-08-21 08:30 project_1: task_3
-2018-08-21 08:36 project_2: task_3
+2018-08-21 08:30 project_1: task_3  # creating tests for task_3
+2018-08-21 08:36 project_2: task_3  # refactoring project_2 UI

--- a/test/unit/test_entry.py
+++ b/test/unit/test_entry.py
@@ -11,48 +11,56 @@ VALID_ENTRIES = [
         'name': "2014-03-23 4:15 An activity",
         'expected_utc': datetime.datetime(2014, 3, 23, 4, 15),
         'expected_name': "An activity",
+        'expected_comment': None,
         'tz': pytz.timezone("GMT"),
     },
     {
         'name': "2014-1-23   09:17   lunch**",
         'expected_utc': datetime.datetime(2014, 1, 23, 9, 17),
         'expected_name': "lunch**",
+        'expected_comment': None,
         'tz': pytz.timezone("GMT"),
     },
     {
         'name': "2014-1-23  10:30+0930  travel",
         'expected_utc': datetime.datetime(2014, 1, 23, 1, 00),
         'expected_name': "travel",
+        'expected_comment': None,
         'tz': pytz.timezone("Europe/London"),
     },
     {
         'name': "2014-1-23  10:30-0930 -work",
         'expected_utc': datetime.datetime(2014, 1, 23, 20, 00),
         'expected_name': "-work",
+        'expected_comment': None,
         'tz': pytz.timezone("Singapore"),
     },
     {
         'name': "2014-1-23  10:30+01:00  break**",
         'expected_utc': datetime.datetime(2014, 1, 23, 9, 30),
         'expected_name': "break**",
+        'expected_comment': None,
         'tz': pytz.timezone("US/Pacific"),
     },
     {
         'name': "2014-1-23  10:30-09:00  break**",
         'expected_utc': datetime.datetime(2014, 1, 23, 19, 30),
         'expected_name': "break**",
+        'expected_comment': None,
         'tz': pytz.timezone("Australia/Sydney"),
     },
     {
         'name': "2014-1-23  10:30 -09:00  break**",
         'expected_utc': datetime.datetime(2014, 1, 22, 23, 30),
         'expected_name': "-09:00  break**",
+        'expected_comment': None,
         'tz': pytz.timezone("Australia/Sydney"),
     },
     {
         'name': "2014-07-23  10:30  +work",  # daylight saving is on, UTC-04:00
         'expected_utc': datetime.datetime(2014, 7, 23, 14, 30),
         'expected_name': "+work",
+        'expected_comment': None,
         'tz': pytz.timezone("US/Eastern"),
     },
     {
@@ -60,7 +68,30 @@ VALID_ENTRIES = [
         "2014-11-23  10:30  -work",  # daylight saving is off, UTC-05:00
         'expected_utc': datetime.datetime(2014, 11, 23, 15, 30),
         'expected_name': "-work",
+        'expected_comment': None,
         'tz': pytz.timezone("US/Eastern"),
+    },
+    {
+        'name': "2014-03-23 4:15 a-project: a_task",
+        'expected_utc': datetime.datetime(2014, 3, 23, 4, 15),
+        'expected_name': "a-project: a_task",
+        'expected_comment': None,
+        'tz': pytz.timezone("GMT"),
+    },
+    {
+        'name': "2014-03-23 4:15 a-project: a_task  and something",
+        'expected_utc': datetime.datetime(2014, 3, 23, 4, 15),
+        'expected_name': "a-project: a_task  and something",
+        'expected_comment': None,
+        'tz': pytz.timezone("GMT"),
+    },
+    {
+        'name':
+        "2014-03-23 4:15 a-project: a_task  and something  # a comment",
+        'expected_utc': datetime.datetime(2014, 3, 23, 4, 15),
+        'expected_name': "a-project: a_task  and something",
+        'expected_comment': "a comment",
+        'tz': pytz.timezone("GMT"),
     }
 ]
 
@@ -73,12 +104,14 @@ class ValidEntry(unittest.TestCase):
     @ddt.data(*VALID_ENTRIES)
     @ddt.unpack
     # pylint: disable=invalid-name
-    def test(self, name, expected_utc, expected_name, tz):
+    # pylint: disable=too-many-arguments
+    def test(self, name, expected_utc, expected_name, expected_comment, tz):
         entry_parser = EntryParser(tz)
         entry = entry_parser.parse(name)
         expected_datetime = tz.fromutc(expected_utc)
         self.assertEqual(entry.datetime, expected_datetime)
         self.assertEqual(entry.name, expected_name)
+        self.assertEqual(entry.comment, expected_comment)
 
 
 @ddt.ddt

--- a/utt/activities.py
+++ b/utt/activities.py
@@ -13,7 +13,8 @@ class Activities:
     def _activities(self):
         for prev_entry, next_entry in _pairwise(self._entries()):
             activity = Activity(next_entry.name, prev_entry.datetime,
-                                next_entry.datetime, False)
+                                next_entry.datetime, False,
+                                comment=next_entry.comment)
             yield activity
 
 

--- a/utt/activity.py
+++ b/utt/activity.py
@@ -9,13 +9,15 @@ class Activity:
         BREAK = 1
         IGNORED = 2
 
-    def __init__(self, name, start, end, is_current_activity):
+    # pylint: disable=too-many-arguments
+    def __init__(self, name, start, end, is_current_activity, comment=None):
         self.name = Name(name)
         self.start = start
         self.end = end
         self.duration = self.end - self.start
         self.type = Activity._type_from_name(name)
         self.is_current_activity = is_current_activity
+        self.comment = comment
 
     def __eq__(self, other):
         return self.name == other.name and \

--- a/utt/commands/add.py
+++ b/utt/commands/add.py
@@ -9,7 +9,11 @@ class AddHandler:
         self._add_entry = add_entry
 
     def __call__(self):
-        self._add_entry(Entry(self._now, self._args.name, False))
+        self._add_entry(
+            Entry(self._now,
+                  self._args.name,
+                  False,
+                  comment=self._args.comment))
 
 
 class AddCommand:
@@ -21,6 +25,9 @@ class AddCommand:
     @staticmethod
     def add_args(parser):
         parser.add_argument("name", help="completed task description")
+        parser.add_argument("-c",
+                            "--comment",
+                            help="comment/annotation for task entry")
 
 
 Command = AddCommand

--- a/utt/commands/report.py
+++ b/utt/commands/report.py
@@ -111,5 +111,11 @@ class ReportCommand:
             default=False,
             help="Show details even for multi-day reports.")
 
+        parser.add_argument(
+            "--comments",
+            action='store_true',
+            default=False,
+            help="Show comments in details sections.")
+
 
 Command = ReportCommand

--- a/utt/commands/stretch.py
+++ b/utt/commands/stretch.py
@@ -18,7 +18,10 @@ class StretchHandler:
         if not entries:
             raise Exception("No entry to stretch")
         latest_entry = entries[-1]
-        new_entry = Entry(self._now, latest_entry.name, False)
+        new_entry = Entry(self._now,
+                          latest_entry.name,
+                          False,
+                          comment=latest_entry.comment)
         self._add_entry(new_entry)
         print("stretched " +
               str(_localize(self._timezone_config, latest_entry)))

--- a/utt/entry.py
+++ b/utt/entry.py
@@ -1,9 +1,16 @@
 class Entry:
-    def __init__(self, datetime, name, is_current_entry):
+    def __init__(self, datetime, name, is_current_entry, comment=None):
         self.datetime = datetime
         self.name = name
         self.is_current_entry = is_current_entry
+        self.comment = comment
 
     def __str__(self):
-        return " ".join(
-            [self.datetime.strftime("%Y-%m-%d %H:%M%z"), self.name])
+        str_components = [
+            self.datetime.strftime("%Y-%m-%d %H:%M%z"), self.name
+        ]
+
+        if self.comment:
+            str_components.append("".join([" # ", self.comment]))
+
+        return " ".join(str_components)

--- a/utt/entry_parser.py
+++ b/utt/entry_parser.py
@@ -4,12 +4,15 @@ from dateutil.parser import parse
 
 from .entry import Entry
 
-WITH_TZ = re.compile(
-    r"(?P<date>\d{4}-\d{1,2}-\d{1,2}\s+\d{1,2}:\d{1,2})(?P<timezone>[+-]{1}\d{2}:{0,1}\d{2})"
-    r"\s+(?P<name>[^\s].*)")
+DATE_REGEX = r"(?P<date>\d{4}-\d{1,2}-\d{1,2}\s+\d{1,2}:\d{1,2})"
+TIMEZONE_REGEX = r"(?P<timezone>[+-]{1}\d{2}:{0,1}\d{2})"
+NAME_REGEX = r"\s+(?P<name>[^\s].*?)"
+COMMENT_REGEX = r"\s{2}#\s(?P<comment>.*$)?"
+WITH_TZ = re.compile("".join([
+    DATE_REGEX, TIMEZONE_REGEX, NAME_REGEX, r"($|", COMMENT_REGEX, ")"]))
 
-WITHOUT_TZ = re.compile(
-    r"(?P<date>\d{4}-\d{1,2}-\d{1,2}\s+\d{1,2}:\d{1,2})\s+(?P<name>[^\s].*)")
+WITHOUT_TZ = re.compile("".join(
+    [DATE_REGEX, NAME_REGEX, r"($|", COMMENT_REGEX, ")"]))
 
 
 class EntryParser:
@@ -37,5 +40,6 @@ class EntryParser:
             date = parse(date_str)
             date = self._local_timezone.localize(date)
 
-        name = match.groupdict()['name']
-        return Entry(date, name, False)
+        name = groupdict['name']
+        comment = groupdict.get('comment')
+        return Entry(date, name, False, comment=comment)

--- a/utt/report/details_section.py
+++ b/utt/report/details_section.py
@@ -12,8 +12,24 @@ class DetailsModel:
 
 
 class DetailsView:
-    def __init__(self, model):
+    def __init__(self, model, show_comments=False):
         self._model = model
+        self.show_comments = show_comments
+
+    def _create_line_for_render(self, activity):
+        format_str = "(%s) %s-%s %s"
+        line = [
+            formatter.format_duration(activity.duration),
+            _format_time(activity.start, self._model.local_timezone),
+            _format_time(activity.end, self._model.local_timezone),
+            activity.name
+        ]
+
+        if self.show_comments and activity.comment:
+            format_str = " ".join([format_str, " # %s"])
+            line.append(activity.comment)
+
+        return format_str % tuple(line)
 
     def render(self, output):
         print(file=output)
@@ -34,13 +50,7 @@ class DetailsView:
                 current_date = activity.start.date()
                 print("{}:".format(current_date.isoformat()), file=output)
                 print("", file=output)
-            print(
-                "(%s) %s-%s %s" %
-                (formatter.format_duration(activity.duration),
-                 _format_time(activity.start, self._model.local_timezone),
-                 _format_time(activity.end, self._model.local_timezone),
-                 activity.name),
-                file=output)
+            print(self._create_line_for_render(activity), file=output)
 
         print(file=output)
 

--- a/utt/report/view.py
+++ b/utt/report/view.py
@@ -18,7 +18,9 @@ class ReportView:
         ActivitiesView(self._report.activities_model).render(output)
         if ((self._report.start_date == self._report.end_date)
                 or (self._report.args.details)):
-            DetailsView(self._report.details_model).render(output)
+            DetailsView(
+                self._report.details_model,
+                show_comments=self._report.args.comments).render(output)
 
     def csv(self, section, output):
         if section == 'summary':
@@ -30,7 +32,9 @@ class ReportView:
         elif section == 'activities':
             view = ActivitiesView(self._report.activities_model)
         elif section == 'details':
-            view = DetailsView(self._report.details_model)
+            view = DetailsView(
+                self._report.details_model,
+                show_comments=self._report.args.comments)
         else:
             view = None
 


### PR DESCRIPTION
When adding an entry a comment can be included with the -c/--comment option:

utt add "test: activity" -c "with a comment"

Comments are separated from the name (project+activity) by two spaces, and a number sign (pound sign/hashtag). A space is expected after the number sign, ex:

2019-12-15 9:00 hello
2019-12-25 9:30 test: activity  # with a comment

Comments can be printed as part of the details section by including --comments option (assuming the report prints a details section), ex:

utt report --comments
utt report --from 2019-12-10 --details --comments